### PR TITLE
Use kIOMasterPortDefault if compiled with SDK<12

### DIFF
--- a/c_src/mac/dext.cpp
+++ b/c_src/mac/dext.cpp
@@ -1,3 +1,5 @@
+#include <filesystem> // Include this before virtual_hid_device_service.hpp to avoid compile error
+
 #include "keyio_mac.hpp"
 
 #include "virtual_hid_device_driver.hpp"
@@ -16,8 +18,7 @@ static pqrs::karabiner::driverkit::virtual_hid_device_driver::hid_report::consum
 
 int init_sink() {
     pqrs::dispatcher::extra::initialize_shared_dispatcher();
-    std::filesystem::path client_socket_file_path("/tmp/karabiner_driverkit_virtual_hid_device_service_client.sock");
-    client = new pqrs::karabiner::driverkit::virtual_hid_device_service::client(client_socket_file_path);
+    client = new pqrs::karabiner::driverkit::virtual_hid_device_service::client();
     auto copy = client;
     client->async_driver_loaded();
     client->async_driver_version_matched();

--- a/c_src/mac/keyio_mac.hpp
+++ b/c_src/mac/keyio_mac.hpp
@@ -157,7 +157,7 @@ void monitor_kb(char *product) {
     CFRelease(cfValue);
     io_iterator_t iter = IO_OBJECT_NULL;
     CFRetain(matching_dictionary);
-    kr = IOServiceGetMatchingServices(kIOMasterPortDefault,
+    kr = IOServiceGetMatchingServices(kIOMainPortDefault,
                                       matching_dictionary,
                                       &iter);
     if(kr != KERN_SUCCESS) {
@@ -166,7 +166,7 @@ void monitor_kb(char *product) {
     }
     listener_loop = CFRunLoopGetCurrent();
     open_matching_devices(product, iter);
-    IONotificationPortRef notification_port = IONotificationPortCreate(kIOMasterPortDefault);
+    IONotificationPortRef notification_port = IONotificationPortCreate(kIOMainPortDefault);
     CFRunLoopSourceRef notification_source = IONotificationPortGetRunLoopSource(notification_port);
     CFRunLoopAddSource(listener_loop, notification_source, kCFRunLoopDefaultMode);
     CFRetain(matching_dictionary);

--- a/c_src/mac/keyio_mac.hpp
+++ b/c_src/mac/keyio_mac.hpp
@@ -6,6 +6,12 @@
 #include <map>
 #include <iostream>
 #include <mach/mach_error.h>
+#include <AvailabilityMacros.h>
+
+/* The name was changed from "Master" to "Main" in Apple SDK 12.0 (Monterey) */
+#if !defined (MAC_OS_X_VERSION_12_0) || (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_12_0)
+    #define kIOMainPortDefault kIOMasterPortDefault
+#endif
 
 int init_sink(void);
 int exit_sink(void);

--- a/c_src/mac/list-keyboards.c
+++ b/c_src/mac/list-keyboards.c
@@ -18,7 +18,7 @@ int main() {
     CFDictionarySetValue(matching_dictionary,CFSTR(kIOHIDDeviceUsageKey),cfValue);
     CFRelease(cfValue);
     io_iterator_t iter = IO_OBJECT_NULL;
-    kern_return_t r = IOServiceGetMatchingServices(kIOMasterPortDefault,
+    kern_return_t r = IOServiceGetMatchingServices(kIOMainPortDefault,
                                                    matching_dictionary,
                                                    &iter);
     if(r != KERN_SUCCESS) {


### PR DESCRIPTION
Compiling against Apple SDK older than 12.0 ends with errors:

`error: use of undeclared identifier 'kIOMainPortDefault'`

That is because `kIOMainPortDefault` was introduced in SDK 12.0 (Monterey) and before that the `kIOMasterPortDefault` should be used.

`kIOMasterPortDefault` was deprecated and was removed in SDK 12.0

References:
- https://developer.apple.com/documentation/iokit/kiomainportdefault
- https://developer.apple.com/documentation/iokit/kiomasterportdefault